### PR TITLE
Add support for saucenao

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 - go get github.com/thehowl/go-osuapi
 - go get github.com/lib/pq
 - go get github.com/op/go-logging
+- go get github.com/GenDoNL/saucenao-go
 
 script:
 - go test -v ./...

--- a/Bot.go
+++ b/Bot.go
@@ -11,17 +11,18 @@ import (
 )
 
 // Set up Logger
-var log = logging.MustGetLogger("DiscordBot")
+var log = logging.MustGetLogger("GenBot")
 var format = logging.MustStringFormatter(
 	`%{color}%{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
 )
 
 // The Config of the bot
 type Config struct {
-	BotToken     string `json:"bottoken"`
-	OsuToken     string `json:"osutoken"`
-	ImgurToken   string `json:"imgurtoken"`
-	DataLocation string `json:"datalocation"`
+	BotToken      string `json:"bottoken"`
+	OsuToken      string `json:"osutoken"`
+	ImgurToken    string `json:"imgurtoken"`
+	SauceNaoToken string `json:"saucenaotoken"`
+	DataLocation  string `json:"datalocation"`
 }
 
 // MessageData is the parsed message, allows for easier access to arguments.

--- a/CommandHelpers.go
+++ b/CommandHelpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"github.com/bwmarrin/discordgo"
+	"net/url"
 	"strings"
 )
 
@@ -94,6 +95,16 @@ func getRolePermissionsByName(ch *discordgo.Channel, sv *discordgo.Guild, name s
 	//get role object for given name
 	role, _ := getRoleByName(name, sv.Roles)
 	return getRolePermissions(role.ID, ch.PermissionOverwrites)
+}
+
+// isValidUrl tests a string to determine if it is a url or not.
+func isValidUrl(toTest string) bool {
+	_, err := url.ParseRequestURI(toTest)
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
 }
 
 // Creates a command in the given server given a name and a message.


### PR DESCRIPTION
This PR adds support for [SauceNao](https://saucenao.com/).

### Changelog
  -  Use `!source <url>` or `!sauce <url>` to get source for an image.
  -  The API key of saucenao is now part of the config file.
